### PR TITLE
[Bug fix]SPAPT/stencil3d error

### DIFF
--- a/testsuite/SPAPT/stencil3d/stencil3d.src5.c
+++ b/testsuite/SPAPT/stencil3d/stencil3d.src5.c
@@ -110,7 +110,7 @@ transform Composite(
     tile = [('i',T1_I,'ii'),('j',T1_J,'jj'),('k',T1_K,'kk'),
             (('ii','i'),T1_Ia,'iii'),(('jj','j'),T1_Ja,'jjj'),(('kk','k'),T1_Ka,'kkk')],
     unrolljam = (['t','i','j'],[U1_I,U1_J,U1_K]),
-    regtile = (['i','j','k'],[RT1_I,RT1_J,RT1_K]),
+    regtile = (['i','j','k'],[RT1_I,RT1_J,RT1_K])
 )
     for (i=1; i<=N-2; i++)
       for (j=1; j<=N-2; j++)
@@ -122,7 +122,7 @@ transform Composite(
     tile = [('i',T2_I,'ii'),('j',T2_J,'jj'),('k',T2_K,'kk'),
             (('ii','i'),T2_Ia,'iii'),(('jj','j'),T2_Ja,'jjj'),(('kk','k'),T2_Ka,'kkk')],
     unrolljam = (['t','i','j'],[U2_I,U2_J,U2_K]),
-    regtile = (['i','j','k'],[RT2_I,RT2_J,RT2_K]),
+    regtile = (['i','j','k'],[RT2_I,RT2_J,RT2_K])
 )
    for (i=1; i<=N-2; i++)
       for (j=1; j<=N-2; j++)

--- a/testsuite/SPAPT/stencil3d/stencil3d.src6.c
+++ b/testsuite/SPAPT/stencil3d/stencil3d.src6.c
@@ -110,7 +110,7 @@ transform Composite(
     tile = [('i',T1_I,'ii'),('j',T1_J,'jj'),('k',T1_K,'kk'),
             (('ii','i'),T1_Ia,'iii'),(('jj','j'),T1_Ja,'jjj'),(('kk','k'),T1_Ka,'kkk')],
     unrolljam = (['t','i','j'],[U1_I,U1_J,U1_K]),
-    regtile = (['i','j','k'],[RT1_I,RT1_J,RT1_K]),
+    regtile = (['i','j','k'],[RT1_I,RT1_J,RT1_K])
 )
     for (i=1; i<=N-2; i++)
       for (j=1; j<=N-2; j++)
@@ -122,7 +122,7 @@ transform Composite(
     tile = [('i',T2_I,'ii'),('j',T2_J,'jj'),('k',T2_K,'kk'),
             (('ii','i'),T2_Ia,'iii'),(('jj','j'),T2_Ja,'jjj'),(('kk','k'),T2_Ka,'kkk')],
     unrolljam = (['t','i','j'],[U2_I,U2_J,U2_K]),
-    regtile = (['i','j','k'],[RT2_I,RT2_J,RT2_K]),
+    regtile = (['i','j','k'],[RT2_I,RT2_J,RT2_K])
 )
    for (i=1; i<=N-2; i++)
       for (j=1; j<=N-2; j++)


### PR DESCRIPTION
The extra comma would cause the parser fail. It throws errors:

ERROR: [orio.module.loop.parser] unexpected symbol ')' at line 1, column 1:
	)
	^
ERROR: [orio.module.loop.parser] unexpected symbol '}' at line 1, column 3:
	  ^
ERROR: orio.main.opt_driver: encountered an error during transformation <orio.module.loop.loop.Loop instance at 0x7f9ff6a8e368>:
 list index out of range

